### PR TITLE
Delete GeoFence API Code

### DIFF
--- a/JCB-Machines/src/main/java/com/wipro/jcb/livelink/app/machines/constants/MessagesList.java
+++ b/JCB-Machines/src/main/java/com/wipro/jcb/livelink/app/machines/constants/MessagesList.java
@@ -53,4 +53,5 @@ public class MessagesList {
 	//Wise URL
 	public static final String SET_LANDMARK_DETAILS = "/v05/WorkManagement/geoFenceService/SetLandmarkDetails";
 	public static final String GET_LANDMARK_DETAILS = "/v05/WorkManagement/geoFenceService/GetLandmarkDetails";
+	public static final String DELETE_LANDMARK_DETAILS = "/v02/WorkManagement/geoFenceService/DeleteLandmark";
 }

--- a/JCB-Machines/src/main/java/com/wipro/jcb/livelink/app/machines/controller/UserProfileController.java
+++ b/JCB-Machines/src/main/java/com/wipro/jcb/livelink/app/machines/controller/UserProfileController.java
@@ -249,4 +249,54 @@ public class UserProfileController {
 					HttpStatus.INTERNAL_SERVER_ERROR);
 		}
 	}
+	
+	/*
+	 * API to Delete GeoFence Details
+	 */
+	@CrossOrigin
+	@Operation(summary = "Delete GeoFence Details")
+	@ApiResponses(value = {
+			@ApiResponse(responseCode = "200", description = "Geofence Deleted Successfully", content = {
+					@Content(mediaType = "application/json", schema = @Schema(implementation = MachineListResponse.class)) }),
+			@ApiResponse(responseCode = "401", description = "Auth Failed", content = {
+					@Content(mediaType = "application/json", schema = @Schema(implementation = ApiError.class)) }),
+			@ApiResponse(responseCode = "500", description = "Request failed", content = {
+					@Content(mediaType = "application/json", schema = @Schema(implementation = ApiError.class)) }) })
+	@PostMapping("/deletegeofence")
+	public ResponseEntity<?> deleteGeofence(@RequestHeader(MessagesList.LOGGED_IN_USER_ROLE) String userDetails,
+			@RequestBody GeofenceRequest geofenceParam) {
+		try {
+			UserDetails userResponse = AuthCommonUtils.getUserDetails(userDetails);
+			final String userName = userResponse.getUserName();
+			log.info("Delete Geofence Method Started for userName:{}", userName);
+			if (userName != null) {
+				if (geofenceParam.getLandmarkId() != null) {
+					String response = machineService.deleteGeofenceDetails(geofenceParam, userName, "optional");
+					if (response.equals(MessagesList.SUCCESS)) {
+						return new ResponseEntity<ResponseData>(
+								new ResponseData("Success", "Geofence Deleted Successfully"), HttpStatus.OK);
+					} else {
+						return new ResponseEntity<ApiError>(
+								new ApiError(HttpStatus.EXPECTATION_FAILED, "Failed", response, null),
+								HttpStatus.EXPECTATION_FAILED);
+					}
+				} else {
+					log.info("Validation Issue");
+					return new ResponseEntity<ApiError>(new ApiError(HttpStatus.EXPECTATION_FAILED,
+							"Landmark Id and VIN can't be null or empty", "Session expired", null),
+							HttpStatus.EXPECTATION_FAILED);
+				}
+			} else {
+				log.info("Delete Geofence : No Vallid session present");
+				return new ResponseEntity<ApiError>(new ApiError(HttpStatus.EXPECTATION_FAILED,
+						"No valid session present", "Session expired", null), HttpStatus.EXPECTATION_FAILED);
+			}
+
+		} catch (final Exception e) {
+			log.error("Issue faced while delete geofence");
+			return new ResponseEntity<ApiError>(new ApiError(HttpURLConnection.HTTP_INTERNAL_ERROR,
+					MessagesList.APP_REQUEST_PROCESSING_FAILED, MessagesList.APP_REQUEST_PROCESSING_FAILED, null),
+					HttpStatus.INTERNAL_SERVER_ERROR);
+		}
+	}
 }

--- a/JCB-Machines/src/main/java/com/wipro/jcb/livelink/app/machines/repo/MachineGeofenceRepository.java
+++ b/JCB-Machines/src/main/java/com/wipro/jcb/livelink/app/machines/repo/MachineGeofenceRepository.java
@@ -1,7 +1,10 @@
 package com.wipro.jcb.livelink.app.machines.repo;
 
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.CrudRepository;
 import org.springframework.stereotype.Repository;
+import org.springframework.transaction.annotation.Transactional;
 
 import com.wipro.jcb.livelink.app.machines.entity.MachineGeofence;
 
@@ -9,5 +12,10 @@ import com.wipro.jcb.livelink.app.machines.entity.MachineGeofence;
 public interface MachineGeofenceRepository extends CrudRepository<MachineGeofence, String> {
 	
 	MachineGeofence findByVin(String vin);
+	
+	@Transactional
+	@Modifying
+	@Query("delete from MachineGeofence a where a.landmarkId =:landmarkId")
+	void deleteByLandmarkId(Integer landmarkId);
 
 }

--- a/JCB-Machines/src/main/java/com/wipro/jcb/livelink/app/machines/service/MachineService.java
+++ b/JCB-Machines/src/main/java/com/wipro/jcb/livelink/app/machines/service/MachineService.java
@@ -117,5 +117,7 @@ public interface MachineService {
     String setGeoFenceParam(GeofenceRequest gfSetRequest,String userName,String machineType,String tokenId) throws Exception;
     
     GeofenceRequest getGeofenceDetails(String vin,String userName,String token);
+    
+    String deleteGeofenceDetails(GeofenceRequest geofenceParam, String userName, String tokenId);
 
 }


### PR DESCRIPTION
Below are the Steps to Execute This API and to Get Successful Response
-----------------------------------------------------------------------
Step:-1
In Legacy APIGateway Project
Under package com.wipro.APIGateway.WebService; -> GeofenceServiceV2::DeleteLandmark, Change port in variable "String urlPath" from "26070" to "27000"
Ex:- String urlPath = "http://localhost:26070/WISE/..." to String urlPath = "http://localhost:27000/WISE/..."

Step:-2
After Above Changes, Need to Make APIGateway, JCBWebAppNewScreens and Wise Applications Up and Running

Step:-3
Hit the below API along with Body from Postman to get the Response
API:- http://localhost:8088/user/machines/deletegeofence  (POST)
Request:-
{
    "vin": "WIPTEST0000111111",
    "landmarkId": 330
}

Note:-
-------
-> Make Sure, "landmarkId" value has to be present in "wise.landmark" Table.
-> Old Request May not work, since the "landmarkId": 330 is already been deleted from "wise.landmark" Table.
-> Try Sending any new value for "landmarkId" from Postman, which should Exist in "wise.landmark" Table.
-> Hardcoded livelinkToken value as "37aa1b15_20240522150705" and passed this livelinkToken in header such as .header("TokenId", livelinkToken) in MachineServiceImpl::deleteGeofenceDetails in JCB-Machines.