### PR TITLE
Delete TimeFence API Code

### DIFF
--- a/JCB-Machines/src/main/java/com/wipro/jcb/livelink/app/machines/constants/MessagesList.java
+++ b/JCB-Machines/src/main/java/com/wipro/jcb/livelink/app/machines/constants/MessagesList.java
@@ -59,4 +59,5 @@ public class MessagesList {
 	public static final String GET_LANDMARK_DETAILS_FOR_USER = "/v05/WorkManagement/geoFenceService/GetLandmarkDetailsForUser";
 	public static final String SET_TIME_FENCE = "/v04/WorkManagement/timeFenceService/SetTimeFence";
 	public static final String GET_TIME_FENCE = "/v04/WorkManagement/timeFenceService/GetTimeFence";
+	public static final String DELETE_TIME_FENCE = "/v02/WorkManagement/timeFenceService/DeleteTimeFence";
 }

--- a/JCB-Machines/src/main/java/com/wipro/jcb/livelink/app/machines/controller/UserProfileController.java
+++ b/JCB-Machines/src/main/java/com/wipro/jcb/livelink/app/machines/controller/UserProfileController.java
@@ -498,4 +498,53 @@ public class UserProfileController {
 					HttpStatus.INTERNAL_SERVER_ERROR);
 		}
 	}
+	
+	/*
+	 * API to Delete TimeFence Details
+	 */
+	@CrossOrigin
+	@Operation(summary = "Delete Timefence Details")
+	@ApiResponses(value = {
+			@ApiResponse(responseCode = "200", description = "Timefence Details Deleted Successfully", content = {
+					@Content(mediaType = "application/json", schema = @Schema(implementation = MachineListResponse.class)) }),
+			@ApiResponse(responseCode = "401", description = "Auth Failed", content = {
+					@Content(mediaType = "application/json", schema = @Schema(implementation = ApiError.class)) }),
+			@ApiResponse(responseCode = "500", description = "Request failed", content = {
+					@Content(mediaType = "application/json", schema = @Schema(implementation = ApiError.class)) }) })
+	@PostMapping("/deletetimefence")
+	public ResponseEntity<?> deletetimefence(@RequestHeader(MessagesList.LOGGED_IN_USER_ROLE) String userDetails,
+			@RequestBody GeofenceRequest geofenceParam) {
+		try {
+			UserDetails userResponse = AuthCommonUtils.getUserDetails(userDetails);
+			final String userName = userResponse.getUserName();
+			log.info("Delete Geofence Method Started " + userName);
+			if (userName != null) {
+				if (geofenceParam.getVin() != null) {
+					String response = machineService.deleteTimefenceDetails(geofenceParam.getVin(), userName, "optional");
+					if (response.equals(MessagesList.SUCCESS)) {
+						return new ResponseEntity<ResponseData>(
+								new ResponseData("Success", "Timefence Deleted Successfully"), HttpStatus.OK);
+					} else {
+						return new ResponseEntity<ApiError>(
+								new ApiError(HttpStatus.EXPECTATION_FAILED, "Failed", response, null),
+								HttpStatus.EXPECTATION_FAILED);
+					}
+				} else {
+					log.info("Validation Issue");
+					return new ResponseEntity<ApiError>(new ApiError(HttpStatus.EXPECTATION_FAILED,
+							"VIN can't be null or empty", "Session expired", null), HttpStatus.EXPECTATION_FAILED);
+				}
+			} else {
+				log.info("Delete Geofence : No Vallid session present");
+				return new ResponseEntity<ApiError>(new ApiError(HttpStatus.EXPECTATION_FAILED,
+						"No valid session present", "Session expired", null), HttpStatus.EXPECTATION_FAILED);
+			}
+
+		} catch (final Exception e) {
+			log.error("Issue faced while delete geofence");
+			return new ResponseEntity<ApiError>(new ApiError(HttpURLConnection.HTTP_INTERNAL_ERROR,
+					MessagesList.APP_REQUEST_PROCESSING_FAILED, MessagesList.APP_REQUEST_PROCESSING_FAILED, null),
+					HttpStatus.INTERNAL_SERVER_ERROR);
+		}
+	}
 }


### PR DESCRIPTION
Below are the Steps to Execute This API and to Get Successful Response
-----------------------------------------------------------------------
Step:-1
In Legacy APIGateway Project
Under package com.wipro.APIGateway.WebService; -> TimefenceServiceV2::DeleteTimeFence, Change port in variable "String urlPath" from "26070" to "27000"
Ex:- String urlPath = "http://localhost:26070/WISE/..." to String urlPath = "http://localhost:27000/WISE/..."

Step:-2
After Above Changes, Need to Make APIGateway, JCBWebAppNewScreens and Wise Applications Up and Running.

Step:-3
Hit the below API along with Body from Postman to get the Response
API:- http://localhost:8088/user/machines/deletetimefence  (POST)
Request:-
{
    "vin": "DUMMY000001234567"
}

Note:-
------
-> Make Sure, this "vin": "DUMMY000001234567" has to be present in "microservices_db.machine_timefence" Table;
-> Old Request May not work, since the "vin": "DUMMY000001234567" is already been deleted from "microservices_db.machine_timefence" Table.
-> Try Sending any new value for "vin" from Postman.
-> Hardcoded livelinkToken value as "37aa1b15_20240522150705" and passed this livelinkToken in header such as .header("TokenId", livelinkToken) in MachineServiceImpl:: deleteTimefenceDetails in JCB-Machines.

Queries Involved During this API Execution in Legacy Wise Code
------------------------------------------------------------------
update asset_profile set operatingStartTime=null, operatingEndTime=null where serialnumber='DUMMY000001234567'
delete from timefence_settings where AssetID='DUMMY000001234567'
delete from notification_preference where AssetID='DUMMY000001234567' and AlertTypeID=3
INSERT INTO Timefence_change_log(AssetID,UpdatedTime,UserID,Status,PartitionKey,Source) ...;